### PR TITLE
 fixed \r issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,7 +40,7 @@ app.get("/api/phonenumbers/parse/file", (req, res) => {
 
 app.post("/api/phonenumbers/parse/file", upload.single("parse"), (req, res) => {
     let filePathToRead = path.join(__dirname, "uploads", req.file.filename)
-    let fileContent = fs.readFileSync(filePathToRead, "UTF8").split('\n');
+    var fileContent = fs.readFileSync(filePathToRead, "UTF8").match(/[^\r\n]+/g);
     console.log(fileContent);
     var filteredNumbers = [];
     if (fileContent) {
@@ -52,7 +52,7 @@ app.post("/api/phonenumbers/parse/file", upload.single("parse"), (req, res) => {
             }
         }
         parser.parseFile(filteredNumbers).then((validPhones) => {
-            console.log(validPhones);
+            //console.log(validPhones);
             res.send(validPhones);
         }).catch((err) => {
             res.send(err);


### PR DESCRIPTION
This PR fixs the bug of \r persisting during file issue.

What I did was replace `.split("\n")` with `.match(/[^\r\n]+/g)`.

It gets rid of the \r and still reproduces the same behavior as before.

I also replace let with `var` and commented out `console.log(validPhones)`;.

Thanks for considering this request.
